### PR TITLE
Remove peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "tinycolor2": "^1.1.2"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
For reasons that are not entirely clear to me, react-color continues to install its own version of react even if the main package has an appropriate version of react already installed. This throws an error in the main app regarding two versions of react. 

Please see: https://github.com/casesandberg/react-color/issues/264 and https://github.com/casesandberg/react-color/issues/101

Some other potential fixes to look into later include:  switching to npm3, and looking to see if this is just a semver bug or something.